### PR TITLE
ArgoCD ingress

### DIFF
--- a/charts/argocd/values.yaml
+++ b/charts/argocd/values.yaml
@@ -4,14 +4,14 @@ argo-cd:
   server:
     extraArgs:
       - --insecure
-      - --rootpath
-      - /argocd
+      # - --rootpath
+      # - /
     ingress:
       enabled: true
-      # hosts:
-      #   - localhost
+      hosts:
+        - argocd.local.env
       paths:
-        - /argocd
+        - /
       # https: true
 configs:
   secret:


### PR DESCRIPTION
Added ingress to [ArgoCD](http://argocd.local.env).

An external-dns must to be configured to automate DNS records creation.